### PR TITLE
Fixed get request parameters not valid

### DIFF
--- a/pyjars/rolestrategy.py
+++ b/pyjars/rolestrategy.py
@@ -55,7 +55,7 @@ class RoleStrategy(object):
 
     def _get(self, api_url, data=None):
         """Return requests.models.Response"""
-        return self._session.get(api_url, data=data)
+        return self._session.get(api_url, params=data)
 
     def _delete(self, api_url):
         """Return requests.models.Response"""


### PR DESCRIPTION
From docs of [requests](https://requests.readthedocs.io/en/master/user/quickstart/), we should use _params_  to make _get_ request